### PR TITLE
Update TODO.md with new CLI command guidelines

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,36 +1,42 @@
+# General Notes
+
+*   **JSON Input/Output**: Most commands will accept JSON from stdin and produce JSON to stdout. Commands should also include command-line arguments for reading JSON from a file and writing JSON to a file.
+*   **Board Handling**:
+    *   If only one compatible board is attached, commands should default to using that board.
+    *   If no board is attached, an appropriate error message should be displayed.
+    *   If multiple compatible boards are attached, commands should either prompt the user to select a board or allow the user to specify a board via a command-line argument.
+
 # TODO: KeyBard CLI - Planned Commands
 
 This file lists planned command-line interface (CLI) commands for KeyBard CLI, based on the non-UI capabilities of the KeyBard core library.
 
-*   [ ] `keybard-cli get keyboard-info`: Pull all available information from the connected keyboard (similar to current `dump` but perhaps with more formatting options or ability to save to a file).
+*   [ ] `keybard-cli get keyboard-info`: Pull all available information from the connected keyboard (replaces the old dump command; pulls all available information from the connected keyboard, perhaps with more formatting options or ability to save to a file).
 *   [ ] `keybard-cli get keymap [--layer N] [--output <format>]`: View keymap, optionally for a specific layer, and specify output format (e.g., JSON, text).
 *   [ ] `keybard-cli set keymap <key_definition> --position <pos> [--layer N]`: Set a specific key on the keymap.
-*   [ ] `keybard-cli load keymap <filepath.json>`: Load a full keymap from a file and apply to the keyboard.
-*   [ ] `keybard-cli save keymap <filepath.json>`: Save the current keyboard keymap to a file.
+*   [ ] `keybard-cli upload keymap <filepath.json>`: Load a full keymap from a file and apply to the keyboard.
+*   [ ] `keybard-cli download keymap <filepath.json>`: Save the current keyboard keymap to a file.
 *   [ ] `keybard-cli list macros`: List all macros.
 *   [ ] `keybard-cli get macro <id_or_name>`: View a specific macro.
-*   [ ] `keybard-cli add macro "<sequence_definition>"`: Add a new macro (e.g., "CTRL+C").
-*   [ ] `keybard-cli edit macro <id_or_name> "<new_sequence_definition>"`: Edit an existing macro.
+*   [ ] `keybard-cli add macro "<sequence_definition>"`: Add a new macro (e.g., "CTRL+C"). (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
+*   [ ] `keybard-cli edit macro <id_or_name> "<new_sequence_definition>"`: Edit an existing macro. (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
 *   [ ] `keybard-cli delete macro <id_or_name>`: Remove a macro.
 *   [ ] `keybard-cli list tapdances`: List all tapdances.
 *   [ ] `keybard-cli get tapdance <id_or_name>`: View a specific tapdance.
-*   [ ] `keybard-cli add tapdance "<sequence_definition>"`: Add a new tapdance.
-*   [ ] `keybard-cli edit tapdance <id_or_name> "<new_sequence_definition>"`: Edit an existing tapdance.
+*   [ ] `keybard-cli add tapdance "<sequence_definition>"`: Add a new tapdance. (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
+*   [ ] `keybard-cli edit tapdance <id_or_name> "<new_sequence_definition>"`: Edit an existing tapdance. (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
 *   [ ] `keybard-cli delete tapdance <id_or_name>`: Remove a tapdance.
 *   [ ] `keybard-cli list combos`: List all combos.
 *   [ ] `keybard-cli get combo <id_or_name>`: View a specific combo.
-*   [ ] `keybard-cli add combo "<key1>+<key2> <action_key>"`: Add a new combo.
-*   [ ] `keybard-cli edit combo <id_or_name> "<new_key1>+<new_key2> <new_action_key>"`: Edit an existing combo.
+*   [ ] `keybard-cli add combo "<key1>+<key2> <action_key>"`: Add a new combo. (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
+*   [ ] `keybard-cli edit combo <id_or_name> "<new_key1>+<new_key2> <new_action_key>"`: Edit an existing combo. (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
 *   [ ] `keybard-cli delete combo <id_or_name>`: Remove a combo.
 *   [ ] `keybard-cli list key-overrides`: List all key overrides.
 *   [ ] `keybard-cli get key-override <id_or_name>`: View a specific key override.
-*   [ ] `keybard-cli add key-override "<trigger_key> <override_key>"`: Add a new key override.
-*   [ ] `keybard-cli edit key-override <id_or_name> "<new_trigger_key> <new_override_key>"`: Edit an existing key override.
+*   [ ] `keybard-cli add key-override "<trigger_key> <override_key>"`: Add a new key override. (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
+*   [ ] `keybard-cli edit key-override <id_or_name> "<new_trigger_key> <new_override_key>"`: Edit an existing key override. (Ideally, these commands should also include additional arguments to allow editing/adding items without needing to provide a full JSON representation of the data.)
 *   [ ] `keybard-cli delete key-override <id_or_name>`: Remove a key override.
 *   [ ] `keybard-cli list qmk-settings`: List all available QMK settings and their current values.
 *   [ ] `keybard-cli get qmk-setting <setting_name>`: View a specific QMK setting.
 *   [ ] `keybard-cli set qmk-setting <setting_name> <value>`: Change a QMK setting.
-*   [ ] `keybard-cli import file <filepath.vil | filepath.svl>`: Upload and apply a `.vil` (Vial keymap) or `.svl` (Svalboard/KeyBard keymap) file to the keyboard.
-*   [ ] `keybard-cli export file <filepath.svl>`: Download the current keyboard configuration to an `.svl` file.
-*   [ ] `keybard-cli set-mode <instant|queued>`: Set the change mode (instant application of changes or queued until explicit commit).
-*   [ ] `keybard-cli commit-changes`: Apply all queued changes to the keyboard (if in 'queued' mode).
+*   [ ] `keybard-cli upload file <filepath.vil | filepath.svl>`: Upload and apply a `.vil` (Vial keymap) or `.svl` (Svalboard/KeyBard keymap) file to the keyboard.
+*   [ ] `keybard-cli download file <filepath.svl>`: Download the current keyboard configuration to an `.svl` file.


### PR DESCRIPTION
This commit updates the TODO.md file to reflect new requirements for the KeyBard CLI commands.

Key changes include:
- Addition of a "General Notes" section covering JSON I/O standards and board auto-detection/selection logic.
- Updates to specific command descriptions:
    - Notes added to add/edit commands for macros, tapdances, combos, and key-overrides suggesting arguments for non-JSON based editing.
    - `get keyboard-info` description updated to state it replaces `dump`.
    - `import file` renamed to `upload file`.
    - `export file` renamed to `download file`.
    - `load keymap` renamed to `upload keymap`.
    - `save keymap` renamed to `download keymap`.
- Removal of `keybard-cli set-mode` and `keybard-cli commit-changes` from the planned commands list.